### PR TITLE
Decouple intro and ending from party_house.tscn

### DIFF
--- a/dancing_npc.gd
+++ b/dancing_npc.gd
@@ -13,7 +13,7 @@ func _ready():
 	jump()
 
 
-func _on_tween_completed(object, key):
+func _on_tween_completed(_object, _key):
 	# I dunno why I use match here, could just be if-else but meh
 	match step:
 		0:

--- a/dancing_npc.gd
+++ b/dancing_npc.gd
@@ -1,7 +1,12 @@
 extends Node2D
+# A dancing NPC with a sprite that tweens up and down.
 
 
-var step = 0
+# Height in pixels for the sprite to jump in the dance.
+export(float) var jump_height = 14
+
+# Checks if the dancing NPC is falling or not.
+var is_falling: bool
 
 onready var sprite = $Sprite
 onready var tween = $Tween
@@ -14,25 +19,23 @@ func _ready():
 
 
 func _on_tween_completed(_object, _key):
-	# I dunno why I use match here, could just be if-else but meh
-	match step:
-		0:
-			fall()
-		1:
-			jump()
+	if not is_falling:
+		fall()
+	else:
+		jump()
+
+
+func fall():
+	is_falling = true
+	tween.interpolate_property(sprite, "position",
+		Vector2(0, -jump_height), Vector2.ZERO, 0.1, Tween.TRANS_LINEAR)
+	tween.start()
 
 
 # Makes a jump animation with a random delay, NPC is bad at following beats.
 func jump():
-	step = 0
+	is_falling = false
 	tween.interpolate_property(sprite, "position",
-		Vector2(0, 0), Vector2(0, -14), 0.1,
+		Vector2.ZERO, Vector2(0, -jump_height), 0.1,
 		Tween.TRANS_LINEAR, Tween.EASE_IN_OUT, rand_range(0.5, 2.0))
-	tween.start()
-
-
-func fall():
-	step = 1
-	tween.interpolate_property(sprite, "position",
-		Vector2(0, -14), Vector2(0, 0), 0.1, Tween.TRANS_LINEAR)
 	tween.start()

--- a/ending.gd
+++ b/ending.gd
@@ -1,0 +1,45 @@
+extends Node2D
+
+
+# If true, NPCs spawn left side of the room in ending. False means right side.
+# This will be alternated on every spawn.
+var spawn_left = true
+# List of possible [scale, y-position] for random y adjustment in NPC spawns.
+var random_scale_y = [[0.085, 502], [0.082, 497], [0.08, 492]]
+
+# Node to spawn the NPCs in.
+onready var npc_spawns = $NPCSpawns
+
+
+func _ready():
+	Global.is_ending = true
+	$PartyProps/Banner/Label.text = Global.get_ending_text()
+	$MagicMonster.appear()
+	randomize()
+	spawn_npcs()
+
+
+# Return to opening scene on interact.
+func _input(event):
+	if event.is_action_pressed("interact") or event.is_action_pressed("jump"):
+		Transition.wipe_in(preload("res://ui/opening.tscn"))
+
+
+# Spawns the party go-er depending on the global ending state.
+func spawn_npcs():
+	for _i in range(Global.total_number_of_npc):
+		# 1. Get the resource or sprite of the npc to spawn.
+		var dancing_npc = preload("res://dancing_npc.tscn").instance()
+		# 2. Spawn them at any x-position from 0 to 1024. y-position ~492.
+		npc_spawns.add_child(dancing_npc, true)
+		var index = randi() % random_scale_y.size()
+		var x_location = rand_range(100, 462) if spawn_left else \
+				rand_range(562, 924)
+		dancing_npc.sprite.z_index = random_scale_y.size() - index
+		dancing_npc.sprite.scale = Vector2(random_scale_y[index][0],
+				random_scale_y[index][0])
+		dancing_npc.global_position = Vector2(x_location,
+				random_scale_y[index][1])
+		if dancing_npc.global_position.x > 512:
+			dancing_npc.scale.x *= -1
+		spawn_left = !spawn_left

--- a/ending.gd
+++ b/ending.gd
@@ -7,9 +7,6 @@ var spawn_left = true
 # List of possible [scale, y-position] for random y adjustment in NPC spawns.
 var random_scale_y = [[0.085, 502], [0.082, 497], [0.08, 492]]
 
-# Node to spawn the NPCs in.
-onready var npc_spawns = $NPCSpawns
-
 
 func _ready():
 	Global.is_ending = true
@@ -26,12 +23,12 @@ func _input(event):
 
 
 # Spawns the party go-er depending on the global ending state.
-func spawn_npcs():
+func spawn_npcs(parent = $NPCSpawns):
 	for _i in range(Global.total_number_of_npc):
 		# 1. Get the resource or sprite of the npc to spawn.
 		var dancing_npc = preload("res://dancing_npc.tscn").instance()
 		# 2. Spawn them at any x-position from 0 to 1024. y-position ~492.
-		npc_spawns.add_child(dancing_npc, true)
+		parent.add_child(dancing_npc, true)
 		var index = randi() % random_scale_y.size()
 		var x_location = rand_range(100, 462) if spawn_left else \
 				rand_range(562, 924)

--- a/ending.tscn
+++ b/ending.tscn
@@ -1,0 +1,174 @@
+[gd_scene load_steps=21 format=2]
+
+[ext_resource path="res://fonts/minimal_3x5.ttf" type="DynamicFontData" id=1]
+[ext_resource path="res://sprites/balloon_red.png" type="Texture" id=2]
+[ext_resource path="res://sprites/cake_plate.png" type="Texture" id=3]
+[ext_resource path="res://sprites/balloon_yellow.png" type="Texture" id=4]
+[ext_resource path="res://sprites/balloon_blue.png" type="Texture" id=5]
+[ext_resource path="res://sprites/cake_cut.png" type="Texture" id=6]
+[ext_resource path="res://sprites/fruit_bowl.png" type="Texture" id=7]
+[ext_resource path="res://sprites/banner.png" type="Texture" id=8]
+[ext_resource path="res://sprites/cake.png" type="Texture" id=9]
+[ext_resource path="res://sprites/table_cloth.png" type="Texture" id=10]
+[ext_resource path="res://party_popper.tscn" type="PackedScene" id=11]
+[ext_resource path="res://sprites/player_stand.png" type="Texture" id=12]
+[ext_resource path="res://animation_dance.tres" type="Animation" id=13]
+[ext_resource path="res://ending.gd" type="Script" id=14]
+[ext_resource path="res://magic_monster.tscn" type="PackedScene" id=15]
+[ext_resource path="res://ui/skip_instruction.tscn" type="PackedScene" id=16]
+
+[sub_resource type="DynamicFont" id=12]
+size = 48
+outline_size = 5
+outline_color = Color( 0.556863, 0.372549, 0.658824, 1 )
+font_data = ExtResource( 1 )
+
+[sub_resource type="Animation" id=15]
+length = 0.001
+tracks/0/type = "bezier"
+tracks/0/path = NodePath(".:position:y")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/keys = {
+"points": PoolRealArray( 0, -0.25, 0, 0.25, 0 ),
+"times": PoolRealArray( 0 )
+}
+
+[sub_resource type="Animation" id=16]
+resource_name = "hover"
+length = 4.0
+loop = true
+tracks/0/type = "bezier"
+tracks/0/path = NodePath(".:position:y")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/keys = {
+"points": PoolRealArray( 0, -0.25, 0, 0.25, 0, -8, -0.25, 0, 0.25, 0, 0, -0.25, 0, 0.25, 0 ),
+"times": PoolRealArray( 0, 2, 4 )
+}
+
+[sub_resource type="Animation" id=10]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/path = NodePath("PlayerSprite:position")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 0,
+"values": [ Vector2( 512, 512 ) ]
+}
+tracks/1/type = "value"
+tracks/1/path = NodePath("PlayerSprite:scale")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 0,
+"values": [ Vector2( 0.1, 0.1 ) ]
+}
+
+[node name="Ending" type="Node2D"]
+script = ExtResource( 14 )
+
+[node name="SkipInstruction" parent="." instance=ExtResource( 16 )]
+
+[node name="PartyProps" type="Node2D" parent="."]
+
+[node name="Banner" type="Sprite" parent="PartyProps"]
+position = Vector2( 512, 154 )
+texture = ExtResource( 8 )
+
+[node name="Label" type="Label" parent="PartyProps/Banner"]
+margin_left = -175.0
+margin_top = -31.0
+margin_right = 175.0
+margin_bottom = 95.0
+grow_horizontal = 2
+grow_vertical = 2
+custom_colors/font_color = Color( 0.937255, 0.858824, 0.0588235, 1 )
+custom_fonts/font = SubResource( 12 )
+text = "Wholesome
+Party"
+align = 1
+valign = 1
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="TableCloth" type="Sprite" parent="PartyProps"]
+position = Vector2( 483, 472 )
+scale = Vector2( 2, 2 )
+texture = ExtResource( 10 )
+
+[node name="CakePlate" type="Sprite" parent="PartyProps"]
+position = Vector2( 524, 448 )
+scale = Vector2( 2, 2 )
+texture = ExtResource( 3 )
+
+[node name="Cake" type="Sprite" parent="PartyProps/CakePlate"]
+visible = false
+position = Vector2( -0.5, -12 )
+texture = ExtResource( 9 )
+
+[node name="CakeCut" type="Sprite" parent="PartyProps/CakePlate"]
+position = Vector2( -0.5, -12 )
+texture = ExtResource( 6 )
+
+[node name="FruitBowl" type="Sprite" parent="PartyProps"]
+position = Vector2( 433, 418 )
+scale = Vector2( 2, 2 )
+texture = ExtResource( 7 )
+
+[node name="Balloons" type="Node2D" parent="PartyProps"]
+
+[node name="BalloonYellow" type="Sprite" parent="PartyProps/Balloons"]
+position = Vector2( 34.5, 369 )
+texture = ExtResource( 4 )
+
+[node name="BalloonRed" type="Sprite" parent="PartyProps/Balloons"]
+position = Vector2( 62.5, 399 )
+texture = ExtResource( 2 )
+
+[node name="BalloonBlue" type="Sprite" parent="PartyProps/Balloons"]
+position = Vector2( 949, 393 )
+texture = ExtResource( 5 )
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="PartyProps/Balloons"]
+autoplay = "hover"
+anims/RESET = SubResource( 15 )
+anims/hover = SubResource( 16 )
+
+[node name="PartyPopper" parent="PartyProps" instance=ExtResource( 11 )]
+position = Vector2( 267, 88 )
+
+[node name="PartyPopper2" parent="PartyProps" instance=ExtResource( 11 )]
+position = Vector2( 741, 88 )
+rotation = 3.14159
+scale = Vector2( 1, -1 )
+
+[node name="NPCSpawns" type="Node2D" parent="."]
+
+[node name="PlayerSprite" type="Sprite" parent="."]
+position = Vector2( 512, 512 )
+scale = Vector2( 0.1, 0.1 )
+z_index = 5
+texture = ExtResource( 12 )
+
+[node name="PlayerPlayer" type="AnimationPlayer" parent="."]
+autoplay = "dance"
+anims/RESET = SubResource( 10 )
+anims/dance = ExtResource( 13 )
+
+[node name="MagicMonster" parent="." instance=ExtResource( 15 )]
+position = Vector2( 278, 320 )

--- a/global.gd
+++ b/global.gd
@@ -12,7 +12,7 @@ func get_ending_text():
 	var text: String
 	
 	if total_number_of_npc >= 19:
-		return "Super-Duper\nWholesome Party"			
+		return "Super-Duper\nWholesome Party"
 	elif total_number_of_npc >= 9:
 		return "Crazy Wholesome\nParty"
 	
@@ -31,8 +31,7 @@ func get_ending_text():
 			text = "Justice League"
 		_:
 			text = "Wholesome"
-				
-				
+	
 	return "%s\nParty" % text
 
 

--- a/introduction.gd
+++ b/introduction.gd
@@ -1,0 +1,27 @@
+extends Node2D
+# Introduction cutscene controller. Most of the interactions are done through
+# signals in the introduction.tscn scene. This is just extra setup code.
+
+
+# Reference to the party house node.
+var party_house
+
+# AnimationPlayer for the PlayerSprite.
+onready var player_player = $PlayerInteraction/PlayerPlayer
+
+
+func _ready():
+	var player_speech2 = $PlayerInteraction/Speech2
+	var player_speech3 = $PlayerInteraction/Speech3
+	if is_instance_valid(party_house):
+		# If party house exists, use its camera after player_speech2.
+		player_speech2.connect("tree_exited", party_house, "view_outside")
+		party_house.connect("house_transformed", player_speech3, "play")
+	else:
+		# Otherwise, go to player_speech3 directly.
+		player_speech2.connect("tree_exited", player_speech3, "play")
+
+
+# Play the shocked animation for the PlayerSprite.
+func shock():
+	player_player.play("shocked")

--- a/introduction.tscn
+++ b/introduction.tscn
@@ -1,0 +1,180 @@
+[gd_scene load_steps=8 format=2]
+
+[ext_resource path="res://introduction.gd" type="Script" id=1]
+[ext_resource path="res://sprites/player_stand.png" type="Texture" id=3]
+[ext_resource path="res://ui/skip_instruction.tscn" type="PackedScene" id=4]
+[ext_resource path="res://magic_monster.tscn" type="PackedScene" id=7]
+[ext_resource path="res://ui/speech.tscn" type="PackedScene" id=8]
+
+[sub_resource type="Animation" id=10]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/path = NodePath("PlayerInteraction/PlayerSprite:position")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 0,
+"values": [ Vector2( 706, 468 ) ]
+}
+tracks/1/type = "value"
+tracks/1/path = NodePath("PlayerInteraction/PlayerSprite:scale")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 0,
+"values": [ Vector2( 0.1, 0.1 ) ]
+}
+tracks/2/type = "value"
+tracks/2/path = NodePath("PlayerInteraction/PlayerSprite:rotation_degrees")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 0,
+"values": [ 0.0 ]
+}
+
+[sub_resource type="Animation" id=11]
+resource_name = "shocked"
+length = 0.2
+tracks/0/type = "value"
+tracks/0/path = NodePath("PlayerInteraction/PlayerSprite:position")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/keys = {
+"times": PoolRealArray( 0, 0.1, 0.2 ),
+"transitions": PoolRealArray( 1, 1, 1 ),
+"update": 0,
+"values": [ Vector2( 706, 468 ), Vector2( 718, 462 ), Vector2( 706, 468 ) ]
+}
+tracks/1/type = "value"
+tracks/1/path = NodePath("PlayerInteraction/PlayerSprite:scale")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ Vector2( -0.1, 0.1 ) ]
+}
+tracks/2/type = "value"
+tracks/2/path = NodePath("PlayerInteraction/PlayerSprite:rotation_degrees")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/keys = {
+"times": PoolRealArray( 0, 0.1, 0.2 ),
+"transitions": PoolRealArray( 1, 1, 1 ),
+"update": 0,
+"values": [ 0.0, 12.3391, 0.0 ]
+}
+
+[node name="Introduction" type="Node2D"]
+script = ExtResource( 1 )
+
+[node name="SkipInstruction" parent="." instance=ExtResource( 4 )]
+show_on_ready = true
+
+[node name="PlayerInteraction" type="Node2D" parent="."]
+
+[node name="PlayerSprite" type="Sprite" parent="PlayerInteraction"]
+position = Vector2( 706, 468 )
+scale = Vector2( 0.1, 0.1 )
+z_index = 5
+texture = ExtResource( 3 )
+
+[node name="Speech1" parent="PlayerInteraction" instance=ExtResource( 8 )]
+position = Vector2( 755, 392 )
+is_skippable = true
+text = "It has been so long since I've
+been to a party..."
+
+[node name="Speech2" parent="PlayerInteraction" instance=ExtResource( 8 )]
+position = Vector2( 755, 392 )
+is_playing = false
+is_skippable = true
+show_on_ready = false
+text = "What is this magical monster?!"
+
+[node name="Speech3" parent="PlayerInteraction" instance=ExtResource( 8 )]
+position = Vector2( 755, 392 )
+is_playing = false
+is_skippable = true
+show_on_ready = false
+text = "Wow! My house!"
+
+[node name="Speech4" parent="PlayerInteraction" instance=ExtResource( 8 )]
+position = Vector2( 755, 392 )
+is_playing = false
+is_skippable = true
+show_on_ready = false
+text = "But I have no one to party with."
+
+[node name="PlayerPlayer" type="AnimationPlayer" parent="PlayerInteraction"]
+root_node = NodePath("../..")
+anims/RESET = SubResource( 10 )
+anims/shocked = SubResource( 11 )
+
+[node name="MonsterInteraction" type="Node2D" parent="."]
+
+[node name="MagicMonster" parent="MonsterInteraction" instance=ExtResource( 7 )]
+position = Vector2( 278, 370 )
+
+[node name="Speech1" parent="MonsterInteraction" instance=ExtResource( 8 )]
+position = Vector2( 352, 314 )
+is_playing = false
+is_skippable = true
+show_on_ready = false
+text = "Then let's throw a party for everyone!!"
+
+[node name="Speech2" parent="MonsterInteraction" instance=ExtResource( 8 )]
+position = Vector2( 352, 314 )
+is_playing = false
+is_skippable = true
+show_on_ready = false
+text = "Have you forgotten about
+the people around you?"
+
+[node name="Speech3" parent="MonsterInteraction" instance=ExtResource( 8 )]
+position = Vector2( 352, 300 )
+is_playing = false
+is_skippable = true
+show_on_ready = false
+text = "Your neighbors! Your friends!
+Close or not, they are part
+of your community."
+
+[node name="Speech4" parent="MonsterInteraction" instance=ExtResource( 8 )]
+position = Vector2( 352, 300 )
+is_playing = false
+is_skippable = true
+show_on_ready = false
+text = "Go, go, go invite them now!
+They wanna party too,
+not just you!"
+
+[connection signal="tree_exited" from="PlayerInteraction/Speech1" to="MonsterInteraction/MagicMonster" method="appear"]
+[connection signal="tree_exited" from="PlayerInteraction/Speech3" to="PlayerInteraction/Speech4" method="play"]
+[connection signal="tree_exited" from="PlayerInteraction/Speech4" to="MonsterInteraction/Speech2" method="play"]
+[connection signal="appeared" from="MonsterInteraction/MagicMonster" to="MonsterInteraction/Speech1" method="play"]
+[connection signal="tree_exited" from="MonsterInteraction/Speech1" to="." method="shock"]
+[connection signal="tree_exited" from="MonsterInteraction/Speech1" to="PlayerInteraction/Speech2" method="play"]
+[connection signal="tree_exited" from="MonsterInteraction/Speech2" to="MonsterInteraction/Speech3" method="play"]
+[connection signal="tree_exited" from="MonsterInteraction/Speech3" to="MonsterInteraction/Speech4" method="play"]
+[connection signal="tree_exited" from="MonsterInteraction/Speech4" to="SkipInstruction" method="skip"]

--- a/magic_monster.gd
+++ b/magic_monster.gd
@@ -1,17 +1,21 @@
 extends Node2D
+# It's a fluffly magic monster!
 
 
-onready var hover_player = $HoverPlayer
+# This signal is emitted when the monster fully appears in the scene.
+signal appeared
+
+
+# Monster's AnimationPlayer.
 onready var monster_player = $MonsterPlayer
-onready var first_speech = $FirstSpeech
 
 
-func _on_monster_player_animation_finished(anim_name):
-	if anim_name == "appear":
-		hover_player.play("hover")
-		if is_instance_valid(first_speech):
-			first_speech.play()
+# Callback for when monster_player animation finishes playing.
+func _on_animation_finished(animation_name):
+	if animation_name == "appear":
+		emit_signal("appeared")
 
 
+# Plays the "appear" animation of the monster.
 func appear():
 	monster_player.play("appear")

--- a/magic_monster.tscn
+++ b/magic_monster.tscn
@@ -1,13 +1,11 @@
-[gd_scene load_steps=16 format=2]
+[gd_scene load_steps=15 format=2]
 
 [ext_resource path="res://sprites/m_1.png" type="Texture" id=1]
-[ext_resource path="res://ui/speech.tscn" type="PackedScene" id=2]
 [ext_resource path="res://sounds/bomb.ogg" type="AudioStream" id=3]
 [ext_resource path="res://sounds/achieved.ogg" type="AudioStream" id=4]
 [ext_resource path="res://magic_monster.gd" type="Script" id=5]
 [ext_resource path="res://sprites/m_2.png" type="Texture" id=6]
 [ext_resource path="res://sprites/m_3.png" type="Texture" id=7]
-
 
 [sub_resource type="SpriteFrames" id=5]
 animations = [ {
@@ -207,6 +205,9 @@ script = ExtResource( 5 )
 
 [node name="Rescale" type="Node2D" parent="."]
 scale = Vector2( 0.08, 0.08 )
+__meta__ = {
+"_editor_description_": "Change the scale of this node to resize the monster instead of the AnimatedSprite, because that one is being handled by the AnimationPlayer."
+}
 
 [node name="AnimatedSprite" type="AnimatedSprite" parent="Rescale"]
 scale = Vector2( 1e-05, 1e-05 )
@@ -237,39 +238,4 @@ stream = ExtResource( 3 )
 [node name="JingleSound" type="AudioStreamPlayer2D" parent="."]
 stream = ExtResource( 4 )
 
-[node name="FirstSpeech" parent="." instance=ExtResource( 2 )]
-position = Vector2( 45, -83 )
-is_playing = false
-is_skippable = true
-show_on_ready = false
-text = "Then let's throw a party for everyone!!"
-
-[node name="SecondSpeech" parent="." instance=ExtResource( 2 )]
-position = Vector2( 45, -83 )
-is_playing = false
-is_skippable = true
-show_on_ready = false
-text = "Have you forgotten about
-the people around you?"
-
-[node name="ThirdSpeech" parent="." instance=ExtResource( 2 )]
-position = Vector2( 45, -83 )
-is_playing = false
-is_skippable = true
-show_on_ready = false
-text = "Your neighbors! Your friends!
-Close or not, they are part
-of your community."
-
-[node name="FourthSpeech" parent="." instance=ExtResource( 2 )]
-position = Vector2( 45, -83 )
-is_playing = false
-is_skippable = true
-show_on_ready = false
-text = "Go, go, go invite them now!
-They wanna party too,
-not just you!"
-
-[connection signal="animation_finished" from="MonsterPlayer" to="." method="_on_monster_player_animation_finished"]
-[connection signal="tree_exited" from="SecondSpeech" to="ThirdSpeech" method="play"]
-[connection signal="tree_exited" from="ThirdSpeech" to="FourthSpeech" method="play"]
+[connection signal="animation_finished" from="MonsterPlayer" to="." method="_on_animation_finished"]

--- a/neighborhood.gd
+++ b/neighborhood.gd
@@ -31,6 +31,7 @@ func _ready():
 	respawn()
 	respawn(false)
 	Transition.wipe_out()
+	MusicPlayer.play_street_song()
 
 
 func _physics_process(_delta):

--- a/party_house.gd
+++ b/party_house.gd
@@ -1,167 +1,43 @@
 extends Node2D
 
 
-const DANCING_NPC = preload("res://dancing_npc.tscn")
+# Emitted when the camera pans back to the transformed party house.
+signal house_transformed
 
-
-# If true, NPCs spawn left side of the room in ending. False means right side.
-# This will be alternated on every spawn.
-var spawn_left = true
-# List of possible [scale, y-position] for random y adjustment in NPC spawns.
-var random_scale_y = [[0.085, 502], [0.082, 497], [0.08, 492]]
 
 onready var camera_player = $CameraPlayer
-onready var house_player = $Outer/AnimationPlayer
-onready var player_player = $PlayerPlayer
-onready var magic_monster = $MagicMonster
-onready var first_speech = $FirstSpeech
-onready var second_speech = $SecondSpeech
-onready var third_speech = $ThirdSpeech
-onready var npc_spawns = $NPCSpawns
-onready var skip_instruction = $SkipInstruction
-
-# Party props.
-onready var props = $Furniture/PartyProps
-onready var banner_label = $Furniture/PartyProps/Banner/Label
-onready var cake = $Furniture/PartyProps/CakePlate/Cake
-onready var cake_cut = $Furniture/PartyProps/CakePlate/CakeCut
-onready var popper_one = $Furniture/PartyProps/PartyPopper/AnimationPlayer
-onready var popper_two = $Furniture/PartyProps/PartyPopper2/AnimationPlayer
+onready var house_player = $Outside/AnimationPlayer
 onready var speaker_player = $Furniture/Speaker/SpeakerPlayer
 
 
 func _ready():
-	# Get ending state from global, if true, then play ending.
+	# Get ending state from global, if true, then load ending scene.
 	if Global.is_ending:
-		play_ending()
+		add_child(preload("res://ending.tscn").instance())
+		$Backwall.color = Color(0.71, 0.67, 0.71, 1.0)
+		$Ceiling.color = Color(0.57, 0.53, 0.56, 1.0)
+		speaker_player.play("play_music")
 	else:
-		skip_instruction.connect("skipped", self, "rearrange_for_party")
+		var intro = preload("res://introduction.tscn").instance()
+		intro.party_house = self
+		add_child(intro)
 
 
-func _input(event):
-	if Global.is_ending and (event.is_action_pressed("interact") or \
-			event.is_action_pressed("jump")):
-		Transition.wipe_in(preload("res://ui/opening.tscn"))
-
-
-# Monster appears after first speech.
-func _on_first_speech_tree_exited():
-	magic_monster.appear()
-
-
-# Camera pans after second speech.
-func _on_second_speech_tree_exited():
-	camera_player.play("pan_camera")
-	MusicPlayer.stop()
-
-
-# Player's second speech plays after monster's first speech.
-func _on_monster_first_tree_exited():
-	second_speech.play() # What is this magical monster?
-	player_player.play("shocked")
-
-
-func _on_camera_animation_finished(anim_name):
-	if anim_name == "pan_camera":
-		house_player.play("change")
-	else:
-		third_speech.play()
+func _on_camera_animation_finished(animation_name):
+	match animation_name:
+		"pan_camera":
+			house_player.play("change")
+		"pan_camera_back":
+			emit_signal("house_transformed")
 
 
 func _on_house_animation_finished(_anim_name):
 	camera_player.play("pan_camera_back")
-	#props.visible = true
 	speaker_player.play("play_music")
 	MusicPlayer.play_street_song()
 
 
-func _on_return_to_main_menu(anim_name):
-	if anim_name == "in":
-		get_tree().change_scene("res://ui/opening.tscn")
-
-
-# Rearanges the scene for the ending.
-func play_ending():
-	rearrange_for_party()
-	_on_first_speech_tree_exited()
-	props.visible = true
-	speaker_player.play("play_music")
-	pop()
-	player_player.play("dance")
-	magic_monster.global_position.y = 320
-	$Backwall.color = Color(0.71, 0.67, 0.71, 1.0)
-	$Ceiling.color = Color(0.57, 0.53, 0.56, 1.0)
-	set_ending_text(Global.get_ending_text())
-	randomize()
-	spawn_npcs()
-
-
-func pop():
-	popper_one.play("pop")
-	popper_two.play("pop")
-	cake.visible = false
-	cake_cut.visible = true
-	banner_label.visible = true
-
-
-# Sorry for the if checks, rushing to complete. Checks are there because
-# player can skip cutscene at any time and I need to destroy the signals or
-# Godot engine will throw error, which is not very nice.
-func rearrange_for_party():
-	camera_player.disconnect("animation_finished", self,
-			"_on_camera_animation_finished")
-	var monster_first = get_node_or_null(
-			"MagicMonster/FirstSpeech")
-	if monster_first:
-		monster_first.disconnect("tree_exited", self,
-				"_on_monster_first_tree_exited")
-	if is_instance_valid(first_speech):
-		first_speech.disconnect("tree_exited", self,
-				"_on_first_speech_tree_exited")
-	if is_instance_valid(second_speech):
-		second_speech.disconnect("tree_exited", self,
-				"_on_second_speech_tree_exited")
-	var fourth_speech = get_node_or_null("FourthSpeech")
-	if is_instance_valid(third_speech):
-		third_speech.disconnect("tree_exited", fourth_speech, "play")
-	var monster_second = get_node_or_null(
-			"MagicMonster/SecondSpeech")
-	if fourth_speech and monster_second:
-		fourth_speech.disconnect("tree_exited", monster_second, "play")
-	var monster_third = get_node_or_null(
-			"MagicMonster/ThirdSpeech")
-	var monster_fourth = get_node_or_null(
-			"MagicMonster/FourthSpeech")
-	if monster_third and monster_fourth:
-		monster_third.disconnect("tree_exited", monster_fourth, "play")
-	if monster_fourth:
-		monster_fourth.disconnect("tree_exited", skip_instruction, "skip")
-	skip_instruction.hide()
-	for node in [first_speech, second_speech, third_speech, fourth_speech,
-			monster_first, monster_second, monster_third, monster_fourth]:
-		if is_instance_valid(node):
-			node.queue_free()
-
-
-func set_ending_text(text):
-	banner_label.text = text
-
-
-# Spawns the party go-er depending on the global ending state.
-func spawn_npcs():
-	for i in range(Global.total_number_of_npc):
-		# 1. Get the resource or sprite of the npc to spawn.
-		var dancing_npc = DANCING_NPC.instance()
-		# 2. Spawn them at any x-position from 0 to 1024. y-position ~492.
-		npc_spawns.add_child(dancing_npc, true)
-		var index = randi() % random_scale_y.size()
-		var x_location = rand_range(100, 462) if spawn_left else \
-				rand_range(562, 924)
-		dancing_npc.sprite.z_index = random_scale_y.size() - index
-		dancing_npc.sprite.scale = Vector2(random_scale_y[index][0],
-				random_scale_y[index][0])
-		dancing_npc.global_position = Vector2(x_location,
-				random_scale_y[index][1])
-		if dancing_npc.global_position.x > 512:
-			dancing_npc.scale.x *= -1
-		spawn_left = !spawn_left
+# Pan camera to outside view and stop the music.
+func view_outside():
+	camera_player.play("pan_camera")
+	MusicPlayer.stop()

--- a/party_house.tscn
+++ b/party_house.tscn
@@ -1,36 +1,20 @@
-[gd_scene load_steps=48 format=2]
+[gd_scene load_steps=27 format=2]
 
 [ext_resource path="res://party_house.gd" type="Script" id=1]
 [ext_resource path="res://sprites/light_window.png" type="Texture" id=2]
-[ext_resource path="res://ui/speech.tscn" type="PackedScene" id=3]
-[ext_resource path="res://magic_monster.tscn" type="PackedScene" id=4]
 [ext_resource path="res://sprites/ring_white.png" type="Texture" id=5]
 [ext_resource path="res://sounds/fly_away.ogg" type="AudioStream" id=6]
 [ext_resource path="res://sounds/cut.ogg" type="AudioStream" id=7]
 [ext_resource path="res://sounds/coin.ogg" type="AudioStream" id=8]
-[ext_resource path="res://sprites/player_stand.png" type="Texture" id=9]
 [ext_resource path="res://sprites/chair.png" type="Texture" id=10]
 [ext_resource path="res://sprites/table.png" type="Texture" id=11]
-[ext_resource path="res://sprites/table_cloth.png" type="Texture" id=12]
-[ext_resource path="res://sprites/banner.png" type="Texture" id=13]
-[ext_resource path="res://sprites/fruit_bowl.png" type="Texture" id=14]
 [ext_resource path="res://sprites/speaker.png" type="Texture" id=15]
-[ext_resource path="res://sprites/cake.png" type="Texture" id=16]
-[ext_resource path="res://sprites/cake_cut.png" type="Texture" id=17]
-[ext_resource path="res://sprites/cake_plate.png" type="Texture" id=18]
-[ext_resource path="res://fonts/minimal_3x5.ttf" type="DynamicFontData" id=19]
-[ext_resource path="res://sprites/balloon_red.png" type="Texture" id=20]
-[ext_resource path="res://sprites/balloon_blue.png" type="Texture" id=21]
-[ext_resource path="res://sprites/balloon_yellow.png" type="Texture" id=22]
-[ext_resource path="res://party_popper.tscn" type="PackedScene" id=23]
 [ext_resource path="res://sprites/house_2.png" type="Texture" id=24]
 [ext_resource path="res://sprites/tree_1.png" type="Texture" id=25]
 [ext_resource path="res://sprites/house_1.png" type="Texture" id=26]
 [ext_resource path="res://sprites/cloud_1.png" type="Texture" id=27]
 [ext_resource path="res://sprites/cloud_2.png" type="Texture" id=28]
-[ext_resource path="res://animation_dance.tres" type="Animation" id=29]
 [ext_resource path="res://sprites/balloon_1.png" type="Texture" id=30]
-[ext_resource path="res://ui/skip_instruction.tscn" type="PackedScene" id=31]
 
 [sub_resource type="Gradient" id=1]
 colors = PoolColorArray( 0.164706, 0.631373, 0.447059, 1, 1, 1, 1, 1 )
@@ -49,7 +33,7 @@ gradient = SubResource( 3 )
 [sub_resource type="Animation" id=8]
 length = 0.001
 tracks/0/type = "value"
-tracks/0/path = NodePath("PartyHouse:modulate")
+tracks/0/path = NodePath("TransformedHouse:modulate")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/imported = false
@@ -157,7 +141,7 @@ tracks/8/keys = {
 "values": [ Color( 0.533333, 0.568627, 0.568627, 1 ) ]
 }
 tracks/9/type = "value"
-tracks/9/path = NodePath("House:modulate")
+tracks/9/path = NodePath("OrdinaryHouse:modulate")
 tracks/9/interp = 1
 tracks/9/loop_wrap = true
 tracks/9/imported = false
@@ -172,7 +156,7 @@ tracks/9/keys = {
 [sub_resource type="Animation" id=7]
 resource_name = "change"
 tracks/0/type = "value"
-tracks/0/path = NodePath("PartyHouse:modulate")
+tracks/0/path = NodePath("TransformedHouse:modulate")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/imported = false
@@ -294,7 +278,7 @@ tracks/9/keys = {
 "values": [ Color( 0.533333, 0.568627, 0.568627, 1 ), Color( 0.568627, 0.533333, 0.564706, 1 ) ]
 }
 tracks/10/type = "value"
-tracks/10/path = NodePath("House:modulate")
+tracks/10/path = NodePath("OrdinaryHouse:modulate")
 tracks/10/interp = 1
 tracks/10/loop_wrap = true
 tracks/10/imported = false
@@ -361,139 +345,6 @@ tracks/1/keys = {
 "transitions": PoolRealArray( 1, 1, 1 ),
 "update": 0,
 "values": [ Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 0 ) ]
-}
-
-[sub_resource type="DynamicFont" id=12]
-size = 48
-outline_size = 5
-outline_color = Color( 0.556863, 0.372549, 0.658824, 1 )
-font_data = ExtResource( 19 )
-
-[sub_resource type="Animation" id=15]
-length = 0.001
-tracks/0/type = "bezier"
-tracks/0/path = NodePath(".:position:x")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/keys = {
-"points": PoolRealArray( 0, -0.25, 0, 0.25, 0 ),
-"times": PoolRealArray( 0 )
-}
-tracks/1/type = "bezier"
-tracks/1/path = NodePath(".:position:y")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/keys = {
-"points": PoolRealArray( 0, -0.25, 0, 0.25, 0 ),
-"times": PoolRealArray( 0 )
-}
-
-[sub_resource type="Animation" id=16]
-resource_name = "hover"
-length = 4.0
-loop = true
-tracks/0/type = "bezier"
-tracks/0/path = NodePath(".:position:x")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/keys = {
-"points": PoolRealArray( 0, -0.25, 0, 0.25, 0, 0, -0.25, 0, 0.25, 0, 0, -0.25, 0, 0.25, 0 ),
-"times": PoolRealArray( 0, 2, 4 )
-}
-tracks/1/type = "bezier"
-tracks/1/path = NodePath(".:position:y")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/keys = {
-"points": PoolRealArray( 0, -0.25, 0, 0.25, 0, -8, -0.25, 0, 0.25, 0, 0, -0.25, 0, 0.25, 0 ),
-"times": PoolRealArray( 0, 2, 4 )
-}
-
-[sub_resource type="Animation" id=10]
-length = 0.001
-tracks/0/type = "value"
-tracks/0/path = NodePath("PlayerSprite:position")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/keys = {
-"times": PoolRealArray( 0 ),
-"transitions": PoolRealArray( 1 ),
-"update": 0,
-"values": [ Vector2( 706, 468 ) ]
-}
-tracks/1/type = "value"
-tracks/1/path = NodePath("PlayerSprite:scale")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/keys = {
-"times": PoolRealArray( 0 ),
-"transitions": PoolRealArray( 1 ),
-"update": 0,
-"values": [ Vector2( 0.1, 0.1 ) ]
-}
-tracks/2/type = "value"
-tracks/2/path = NodePath("PlayerSprite:rotation_degrees")
-tracks/2/interp = 1
-tracks/2/loop_wrap = true
-tracks/2/imported = false
-tracks/2/enabled = true
-tracks/2/keys = {
-"times": PoolRealArray( 0 ),
-"transitions": PoolRealArray( 1 ),
-"update": 0,
-"values": [ 0.0 ]
-}
-
-[sub_resource type="Animation" id=11]
-resource_name = "shocked"
-length = 0.2
-tracks/0/type = "value"
-tracks/0/path = NodePath("PlayerSprite:position")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/keys = {
-"times": PoolRealArray( 0, 0.1, 0.2 ),
-"transitions": PoolRealArray( 1, 1, 1 ),
-"update": 0,
-"values": [ Vector2( 706, 468 ), Vector2( 718, 462 ), Vector2( 706, 468 ) ]
-}
-tracks/1/type = "value"
-tracks/1/path = NodePath("PlayerSprite:scale")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/keys = {
-"times": PoolRealArray( 0 ),
-"transitions": PoolRealArray( 1 ),
-"update": 1,
-"values": [ Vector2( -0.1, 0.1 ) ]
-}
-tracks/2/type = "value"
-tracks/2/path = NodePath("PlayerSprite:rotation_degrees")
-tracks/2/interp = 1
-tracks/2/loop_wrap = true
-tracks/2/imported = false
-tracks/2/enabled = true
-tracks/2/keys = {
-"times": PoolRealArray( 0, 0.1, 0.2 ),
-"transitions": PoolRealArray( 1, 1, 1 ),
-"update": 0,
-"values": [ 0.0, 12.3391, 0.0 ]
 }
 
 [sub_resource type="Animation" id=5]
@@ -596,78 +447,75 @@ tracks/2/keys = {
 [node name="PartyHouse" type="Node2D"]
 script = ExtResource( 1 )
 
-[node name="SkipInstruction" parent="." instance=ExtResource( 31 )]
-show_on_ready = true
-
-[node name="Outer" type="Node2D" parent="."]
+[node name="Outside" type="Node2D" parent="."]
 position = Vector2( 0, -1773 )
 
-[node name="Gradient" type="Sprite" parent="Outer"]
+[node name="Gradient" type="Sprite" parent="Outside"]
 position = Vector2( 545.004, -133.999 )
 rotation = 1.5708
 scale = Vector2( 0.436021, 2282.12 )
 texture = SubResource( 2 )
 
-[node name="Ground" type="Sprite" parent="Outer/Gradient"]
+[node name="Ground" type="Sprite" parent="Outside/Gradient"]
 position = Vector2( 1105.62, -0.00280085 )
 scale = Vector2( 0.781819, 1 )
 texture = SubResource( 4 )
 
-[node name="Cloud2" type="Sprite" parent="Outer"]
+[node name="Cloud" type="Sprite" parent="Outside"]
+position = Vector2( 192, 60 )
+texture = ExtResource( 27 )
+
+[node name="Cloud2" type="Sprite" parent="Outside"]
 position = Vector2( 950, 54 )
 scale = Vector2( 0.5, 0.5 )
 texture = ExtResource( 28 )
 
-[node name="Cloud1" type="Sprite" parent="Outer"]
-position = Vector2( 192, 60 )
-texture = ExtResource( 27 )
-
-[node name="House" type="Sprite" parent="Outer"]
-position = Vector2( 501, 359 )
-scale = Vector2( 0.3, 0.3 )
-texture = ExtResource( 26 )
-
-[node name="House2" type="Sprite" parent="Outer"]
+[node name="BackgroundHouse" type="Sprite" parent="Outside"]
 modulate = Color( 1, 1, 1, 0.745098 )
 position = Vector2( 30, 434 )
 scale = Vector2( 0.15, 0.15 )
 texture = ExtResource( 24 )
 
-[node name="PartyHouse" type="Sprite" parent="Outer"]
+[node name="OrdinaryHouse" type="Sprite" parent="Outside"]
+position = Vector2( 501, 359 )
+scale = Vector2( 0.3, 0.3 )
+texture = ExtResource( 26 )
+
+[node name="TransformedHouse" type="Sprite" parent="Outside"]
 modulate = Color( 1, 1, 1, 0 )
 position = Vector2( 501, 359 )
 scale = Vector2( 0.3, 0.3 )
 texture = ExtResource( 26 )
 
-[node name="Balloon1" type="Sprite" parent="Outer/PartyHouse"]
+[node name="Balloon1" type="Sprite" parent="Outside/TransformedHouse"]
 position = Vector2( -910, 349.999 )
 scale = Vector2( 0.3, 0.3 )
 texture = ExtResource( 30 )
 
-[node name="Balloon2" type="Sprite" parent="Outer/PartyHouse"]
+[node name="Balloon2" type="Sprite" parent="Outside/TransformedHouse"]
 position = Vector2( 923.334, 349.999 )
 scale = Vector2( 0.3, 0.3 )
 texture = ExtResource( 30 )
 
-[node name="Balloon3" type="Sprite" parent="Outer/PartyHouse"]
+[node name="Balloon3" type="Sprite" parent="Outside/TransformedHouse"]
 position = Vector2( 390, 349.999 )
 scale = Vector2( -0.3, 0.3 )
 texture = ExtResource( 30 )
 
-[node name="Balloon4" type="Sprite" parent="Outer/PartyHouse"]
+[node name="Balloon4" type="Sprite" parent="Outside/TransformedHouse"]
 position = Vector2( -380, 349.999 )
 scale = Vector2( -0.3, 0.3 )
 texture = ExtResource( 30 )
 
-[node name="Tree1" type="Sprite" parent="Outer"]
+[node name="Tree" type="Sprite" parent="Outside"]
 position = Vector2( 852, 337 )
 scale = Vector2( 0.2, 0.2 )
 texture = ExtResource( 25 )
 
-[node name="Road" type="Sprite" parent="Outer"]
+[node name="Road" type="Sprite" parent="Outside"]
 position = Vector2( 420, 455 )
 
-[node name="PlaceholderPavement" type="ColorRect" parent="Outer/Road"]
+[node name="PlaceholderPavement" type="ColorRect" parent="Outside/Road"]
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -682,7 +530,7 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Base" type="ColorRect" parent="Outer/Road/PlaceholderPavement"]
+[node name="Base" type="ColorRect" parent="Outside/Road/PlaceholderPavement"]
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -697,7 +545,7 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Shadow" type="ColorRect" parent="Outer/Road/PlaceholderPavement/Base"]
+[node name="Shadow" type="ColorRect" parent="Outside/Road/PlaceholderPavement/Base"]
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -712,7 +560,7 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="PlaceholderRoad" type="ColorRect" parent="Outer/Road"]
+[node name="PlaceholderRoad" type="ColorRect" parent="Outside/Road"]
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -727,29 +575,29 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="RingWhite" type="Sprite" parent="Outer"]
+[node name="RingWhite" type="Sprite" parent="Outside"]
 modulate = Color( 1, 1, 1, 0 )
 position = Vector2( 503, 415 )
 scale = Vector2( 15, 15 )
 texture = ExtResource( 5 )
 
-[node name="RingWhite2" type="Sprite" parent="Outer"]
+[node name="RingWhite2" type="Sprite" parent="Outside"]
 modulate = Color( 1, 1, 1, 0 )
 position = Vector2( 503, 415 )
 scale = Vector2( 15, 15 )
 texture = ExtResource( 5 )
 
-[node name="RingWhite3" type="Sprite" parent="Outer"]
+[node name="RingWhite3" type="Sprite" parent="Outside"]
 modulate = Color( 1, 1, 1, 0 )
 position = Vector2( 503, 415 )
 scale = Vector2( 15, 15 )
 texture = ExtResource( 5 )
 
-[node name="AnimationPlayer" type="AnimationPlayer" parent="Outer"]
+[node name="AnimationPlayer" type="AnimationPlayer" parent="Outside"]
 anims/RESET = SubResource( 8 )
 anims/change = SubResource( 7 )
 
-[node name="HouseAudio" type="AudioStreamPlayer2D" parent="Outer"]
+[node name="HouseAudio" type="AudioStreamPlayer2D" parent="Outside"]
 position = Vector2( 503, 393 )
 stream = ExtResource( 8 )
 volume_db = -4.0
@@ -771,7 +619,7 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Floor2" type="ColorRect" parent="."]
+[node name="FloorOutline" type="ColorRect" parent="."]
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -902,121 +750,9 @@ position = Vector2( 485, 479 )
 scale = Vector2( 2, 2 )
 texture = ExtResource( 11 )
 
-[node name="PartyProps" type="Node2D" parent="Furniture"]
-visible = false
-
-[node name="Banner" type="Sprite" parent="Furniture/PartyProps"]
-position = Vector2( 512, 154 )
-texture = ExtResource( 13 )
-
-[node name="Label" type="Label" parent="Furniture/PartyProps/Banner"]
-visible = false
-margin_left = -175.0
-margin_top = -31.0
-margin_right = 175.0
-margin_bottom = 95.0
-grow_horizontal = 2
-grow_vertical = 2
-custom_colors/font_color = Color( 0.937255, 0.858824, 0.0588235, 1 )
-custom_fonts/font = SubResource( 12 )
-text = "Wholesome
-Party"
-align = 1
-valign = 1
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="TableCloth" type="Sprite" parent="Furniture/PartyProps"]
-position = Vector2( 483, 472 )
-scale = Vector2( 2, 2 )
-texture = ExtResource( 12 )
-
-[node name="CakePlate" type="Sprite" parent="Furniture/PartyProps"]
-position = Vector2( 524, 448 )
-scale = Vector2( 2, 2 )
-texture = ExtResource( 18 )
-
-[node name="Cake" type="Sprite" parent="Furniture/PartyProps/CakePlate"]
-position = Vector2( -0.5, -12 )
-texture = ExtResource( 16 )
-
-[node name="CakeCut" type="Sprite" parent="Furniture/PartyProps/CakePlate"]
-visible = false
-position = Vector2( -0.5, -12 )
-texture = ExtResource( 17 )
-
-[node name="FruitBowl" type="Sprite" parent="Furniture/PartyProps"]
-position = Vector2( 433, 418 )
-scale = Vector2( 2, 2 )
-texture = ExtResource( 14 )
-
-[node name="Balloons" type="Node2D" parent="Furniture/PartyProps"]
-
-[node name="BalloonYellow" type="Sprite" parent="Furniture/PartyProps/Balloons"]
-position = Vector2( 13, 369 )
-texture = ExtResource( 22 )
-
-[node name="BalloonRed" type="Sprite" parent="Furniture/PartyProps/Balloons"]
-position = Vector2( 41, 399 )
-texture = ExtResource( 20 )
-
-[node name="BalloonBlue" type="Sprite" parent="Furniture/PartyProps/Balloons"]
-position = Vector2( 944, 393 )
-texture = ExtResource( 21 )
-
-[node name="AnimationPlayer" type="AnimationPlayer" parent="Furniture/PartyProps/Balloons"]
-autoplay = "hover"
-anims/RESET = SubResource( 15 )
-anims/hover = SubResource( 16 )
-
-[node name="PartyPopper" parent="Furniture/PartyProps" instance=ExtResource( 23 )]
-position = Vector2( 267, 88 )
-
-[node name="PartyPopper2" parent="Furniture/PartyProps" instance=ExtResource( 23 )]
-position = Vector2( 741, 88 )
-rotation = 3.14159
-scale = Vector2( 1, -1 )
-
-[node name="NPCSpawns" type="Node2D" parent="."]
-
-[node name="PlayerSprite" type="Sprite" parent="."]
-position = Vector2( 706, 468 )
-scale = Vector2( 0.1, 0.1 )
-z_index = 5
-texture = ExtResource( 9 )
-
-[node name="FirstSpeech" parent="." instance=ExtResource( 3 )]
-position = Vector2( 755, 392 )
-is_skippable = true
-text = "It has been so long since I've
-been to a party..."
-
-[node name="SecondSpeech" parent="." instance=ExtResource( 3 )]
-position = Vector2( 755, 392 )
-is_playing = false
-is_skippable = true
-show_on_ready = false
-text = "What is this magical monster?!"
-
-[node name="ThirdSpeech" parent="." instance=ExtResource( 3 )]
-position = Vector2( 755, 392 )
-is_playing = false
-is_skippable = true
-show_on_ready = false
-text = "Wow! My house!"
-
-[node name="FourthSpeech" parent="." instance=ExtResource( 3 )]
-position = Vector2( 755, 392 )
-is_playing = false
-is_skippable = true
-show_on_ready = false
-text = "But I have no one to party with."
-
-[node name="PlayerPlayer" type="AnimationPlayer" parent="."]
-anims/RESET = SubResource( 10 )
-anims/dance = ExtResource( 29 )
-anims/shocked = SubResource( 11 )
+[node name="Camera2D" type="Camera2D" parent="."]
+position = Vector2( 512, 300 )
+current = true
 
 [node name="CameraPlayer" type="AnimationPlayer" parent="."]
 anims/RESET = SubResource( 5 )
@@ -1027,35 +763,5 @@ anims/pan_camera_back = SubResource( 9 )
 stream = ExtResource( 7 )
 volume_db = -20.0
 
-[node name="Camera2D" type="Camera2D" parent="."]
-position = Vector2( 512, 300 )
-current = true
-
-[node name="MagicMonster" parent="." instance=ExtResource( 4 )]
-position = Vector2( 278, 370 )
-
-[node name="AnimatedSprite" parent="MagicMonster/Rescale" index="0"]
-frame = 0
-
-[node name="FirstSpeech" parent="MagicMonster" index="6"]
-position = Vector2( 53.9995, -42 )
-
-[node name="SecondSpeech" parent="MagicMonster" index="7"]
-position = Vector2( 53.9995, -50 )
-
-[node name="ThirdSpeech" parent="MagicMonster" index="8"]
-position = Vector2( 53.9995, -59 )
-
-[node name="FourthSpeech" parent="MagicMonster" index="9"]
-position = Vector2( 54, -59 )
-
-[connection signal="animation_finished" from="Outer/AnimationPlayer" to="." method="_on_house_animation_finished"]
-[connection signal="tree_exited" from="FirstSpeech" to="." method="_on_first_speech_tree_exited"]
-[connection signal="tree_exited" from="SecondSpeech" to="." method="_on_second_speech_tree_exited"]
-[connection signal="tree_exited" from="ThirdSpeech" to="FourthSpeech" method="play"]
-[connection signal="tree_exited" from="FourthSpeech" to="MagicMonster/SecondSpeech" method="play"]
+[connection signal="animation_finished" from="Outside/AnimationPlayer" to="." method="_on_house_animation_finished"]
 [connection signal="animation_finished" from="CameraPlayer" to="." method="_on_camera_animation_finished"]
-[connection signal="tree_exited" from="MagicMonster/FirstSpeech" to="." method="_on_monster_first_tree_exited"]
-[connection signal="tree_exited" from="MagicMonster/FourthSpeech" to="SkipInstruction" method="skip"]
-
-[editable path="MagicMonster"]

--- a/party_popper.tscn
+++ b/party_popper.tscn
@@ -336,6 +336,7 @@ node_b = NodePath("../RibbonYellow")
 softness = 5.0
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+autoplay = "pop"
 anims/RESET = SubResource( 4 )
 anims/pop = SubResource( 5 )
 

--- a/ui/opening.gd
+++ b/ui/opening.gd
@@ -3,9 +3,9 @@ extends Node2D
 
 func _ready():
 	if Global.is_ending:
+		Global.reset()
 		Transition.wipe_out()
 		MusicPlayer.play_intro_song()
-		Global.reset()
 
 
 func _process(delta):

--- a/ui/opening.gd
+++ b/ui/opening.gd
@@ -8,7 +8,8 @@ func _ready():
 		MusicPlayer.play_intro_song()
 
 
-func _process(delta):
+func _process(_delta):
 	if Input.is_action_just_pressed("interact") or \
 			Input.is_action_just_pressed("jump"):
-		get_tree().change_scene("res://party_house.tscn")
+		if get_tree().change_scene("res://party_house.tscn") != OK:
+			push_error("Critical error! Failed to load starting scene.")

--- a/ui/skip_instruction.gd
+++ b/ui/skip_instruction.gd
@@ -50,5 +50,4 @@ func skip():
 		is_skipping = true
 		Global.reset()
 		Transition.wipe_in(preload("res://neighborhood.tscn"))
-		MusicPlayer.play_street_song()
 		emit_signal("skipped")

--- a/ui/speech.gd
+++ b/ui/speech.gd
@@ -82,6 +82,7 @@ func play():
 	show_bubble()
 	is_playing = true
 
+
 # Plays the show animation of the speech bubble.
 func show_bubble():
 	animation_player.play("show")


### PR DESCRIPTION
This pull request does the following things:

1. Introduction is in its own scene now. The idea is that the dialogue between player and monster can happen in any level, any background and should be easy to edit. You should be able to run introduction.tscn on its own, and the dialogue will play out without any problems.
2. Same for ending.tscn.
3. Code to handle these cutscenes should be much more separated and reduced now.

Review and check if the scene structure of `party_house.tscn`, `introduction.tscn` and `ending.tscn` is preferable, or if it should be more separated. Check .gd files that were changed in this PR and see if they are up to standard and if they are encapsulated correctly / belong in the right place / clear separation of concern.